### PR TITLE
Set initial date or time on datepicker and timepicker

### DIFF
--- a/src/main/java/me/nucleartux/date/DateFormatHelper.java
+++ b/src/main/java/me/nucleartux/date/DateFormatHelper.java
@@ -1,0 +1,29 @@
+package me.nucleartux.date;
+
+import java.util.Calendar;
+import java.util.Locale;
+import java.text.SimpleDateFormat;
+import java.text.ParseException;
+
+public class DateFormatHelper {
+  public static Calendar parseDate(String date) {
+    Calendar initialDate = Calendar.getInstance();
+
+    if (date != null && date != "")
+    {
+      SimpleDateFormat df = new SimpleDateFormat();
+
+      try
+      {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
+        initialDate.setTime(sdf.parse(date));
+      }
+      catch (ParseException e)
+      {
+        return Calendar.getInstance();
+      }
+    }
+
+    return initialDate;
+  }
+}

--- a/src/main/java/me/nucleartux/date/DateModule.java
+++ b/src/main/java/me/nucleartux/date/DateModule.java
@@ -9,10 +9,7 @@ import com.facebook.react.bridge.Callback;
 
 import java.util.Map;
 import java.util.HashMap;
-import java.util.Calendar;
-import java.util.Locale;
-import java.text.SimpleDateFormat;
-import java.text.ParseException;
+
 
 import android.support.v4.app.DialogFragment;
 import android.app.Activity;
@@ -38,7 +35,7 @@ public class DateModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void showDatepickerWithInitialDate(String initialDateString, Callback errorCallback, Callback successCallback) {
-    DialogFragment dateDialog = new DatePicker(parseDate(initialDateString), errorCallback, successCallback);
+    DialogFragment dateDialog = new DatePicker(DateFormatHelper.parseDate(initialDateString), errorCallback, successCallback);
     dateDialog.show(mActivity.getSupportFragmentManager(), "datePicker");
   }
 
@@ -48,31 +45,8 @@ public class DateModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void showTimepickerWithInitialDate(String initialDateString, Callback errorCallback, Callback successCallback) {
-    DialogFragment dateDialog = new TimePicker(parseDate(initialDateString), errorCallback, successCallback);
+  public void showTimepickerWithInitialTime(String initialDateString, Callback errorCallback, Callback successCallback) {
+    DialogFragment dateDialog = new TimePicker(DateFormatHelper.parseDate(initialDateString), errorCallback, successCallback);
     dateDialog.show(mActivity.getSupportFragmentManager(), "timePicker");
-  }
-
-  private Calendar parseDate(String date)
-  {
-    Calendar initialDate = null;
-
-    if (date != null && date != "")
-    {
-      SimpleDateFormat df = new SimpleDateFormat();
-
-      try
-      {
-        initialDate = Calendar.getInstance();
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
-        initialDate.setTime(sdf.parse(date));
-      }
-      catch (ParseException e)
-      {
-        return null;
-      }
-    }
-
-    return initialDate;
   }
 }

--- a/src/main/java/me/nucleartux/date/DateModule.java
+++ b/src/main/java/me/nucleartux/date/DateModule.java
@@ -9,6 +9,10 @@ import com.facebook.react.bridge.Callback;
 
 import java.util.Map;
 import java.util.HashMap;
+import java.util.Calendar;
+import java.util.Locale;
+import java.text.SimpleDateFormat;
+import java.text.ParseException;
 
 import android.support.v4.app.DialogFragment;
 import android.app.Activity;
@@ -29,13 +33,46 @@ public class DateModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void showDatepicker(Callback errorCallback, Callback successCallback) {
-    DialogFragment dateDialog = new DatePicker(errorCallback, successCallback);
+    this.showDatepickerWithInitialDate(null, errorCallback, successCallback);
+  }
+
+  @ReactMethod
+  public void showDatepickerWithInitialDate(String initialDateString, Callback errorCallback, Callback successCallback) {
+    DialogFragment dateDialog = new DatePicker(parseDate(initialDateString), errorCallback, successCallback);
     dateDialog.show(mActivity.getSupportFragmentManager(), "datePicker");
   }
 
   @ReactMethod
   public void showTimepicker(Callback errorCallback, Callback successCallback) {
-    DialogFragment dateDialog = new TimePicker(errorCallback, successCallback);
+    this.showTimepickerWithInitialDate(null, errorCallback, successCallback);
+  }
+
+  @ReactMethod
+  public void showTimepickerWithInitialDate(String initialDateString, Callback errorCallback, Callback successCallback) {
+    DialogFragment dateDialog = new TimePicker(parseDate(initialDateString), errorCallback, successCallback);
     dateDialog.show(mActivity.getSupportFragmentManager(), "timePicker");
+  }
+
+  private Calendar parseDate(String date)
+  {
+    Calendar initialDate = null;
+
+    if (date != null && date != "")
+    {
+      SimpleDateFormat df = new SimpleDateFormat();
+
+      try
+      {
+        initialDate = Calendar.getInstance();
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
+        initialDate.setTime(sdf.parse(date));
+      }
+      catch (ParseException e)
+      {
+        return null;
+      }
+    }
+
+    return initialDate;
   }
 }

--- a/src/main/java/me/nucleartux/date/DatePicker.java
+++ b/src/main/java/me/nucleartux/date/DatePicker.java
@@ -30,20 +30,9 @@ public class DatePicker extends DialogFragment
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        Calendar c = null;
-
-        if (mInitialDate == null)
-        {
-          c = Calendar.getInstance();
-        }
-        else
-        {
-          c = mInitialDate;
-        }
-
-        int year = c.get(Calendar.YEAR);
-        int month = c.get(Calendar.MONTH);
-        int day = c.get(Calendar.DAY_OF_MONTH);
+        int year = mInitialDate.get(Calendar.YEAR);
+        int month = mInitialDate.get(Calendar.MONTH);
+        int day = mInitialDate.get(Calendar.DAY_OF_MONTH);
 
         Dialog picker = new DatePickerDialog(getActivity(), this,
                 year, month, day);

--- a/src/main/java/me/nucleartux/date/DatePicker.java
+++ b/src/main/java/me/nucleartux/date/DatePicker.java
@@ -18,17 +18,29 @@ public class DatePicker extends DialogFragment
     private Callback mErrorCallback;
     private Callback mSuccessCallback;
     private boolean isCalled;
+    private Calendar mInitialDate;
 
-    public DatePicker(Callback errorCallback, Callback successCallback)
+    public DatePicker(Calendar initialDate, Callback errorCallback, Callback successCallback)
     {
         isCalled = false;
         mErrorCallback = errorCallback;
         mSuccessCallback = successCallback;
+        mInitialDate = initialDate;
     }
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        final Calendar c = Calendar.getInstance();
+        Calendar c = null;
+
+        if (mInitialDate == null)
+        {
+          c = Calendar.getInstance();
+        }
+        else
+        {
+          c = mInitialDate;
+        }
+
         int year = c.get(Calendar.YEAR);
         int month = c.get(Calendar.MONTH);
         int day = c.get(Calendar.DAY_OF_MONTH);

--- a/src/main/java/me/nucleartux/date/TimePicker.java
+++ b/src/main/java/me/nucleartux/date/TimePicker.java
@@ -33,19 +33,8 @@ public class TimePicker extends DialogFragment
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        Calendar c = null;
-
-        if (mInitialDate == null)
-        {
-          c = Calendar.getInstance();
-        }
-        else
-        {
-          c = mInitialDate;
-        }
-
-        int hour = c.get(Calendar.HOUR_OF_DAY);
-        int minute = c.get(Calendar.MINUTE);
+        int hour = mInitialDate.get(Calendar.HOUR_OF_DAY);
+        int minute = mInitialDate.get(Calendar.MINUTE);
 
         // Create a new instance of TimePickerDialog and return it
         return new TimePickerDialog(getActivity(), this, hour, minute,

--- a/src/main/java/me/nucleartux/date/TimePicker.java
+++ b/src/main/java/me/nucleartux/date/TimePicker.java
@@ -21,16 +21,29 @@ public class TimePicker extends DialogFragment
     private Callback mSuccessCallback;
     private boolean isCalled;
 
-    public TimePicker(Callback errorCallback, Callback successCallback)
+    private Calendar mInitialDate;
+
+    public TimePicker(Calendar initialDate, Callback errorCallback, Callback successCallback)
     {
         isCalled = false;
         mErrorCallback = errorCallback;
         mSuccessCallback = successCallback;
+        mInitialDate = initialDate;
     }
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        final Calendar c = Calendar.getInstance();
+        Calendar c = null;
+
+        if (mInitialDate == null)
+        {
+          c = Calendar.getInstance();
+        }
+        else
+        {
+          c = mInitialDate;
+        }
+
         int hour = c.get(Calendar.HOUR_OF_DAY);
         int minute = c.get(Calendar.MINUTE);
 


### PR DESCRIPTION
Currently the implementation assumes you will be passing a ISO formatted string since we can't pass a actual JS date object through the bridge. Additionally I had to setup two additional methods to be called since you can't overload methods exposed to react native. 

This implementation is fairly crude but it does get the job done. I will likely be sending a few more PRs to clean this up as well as possibly add some more functionality like coloring of the pickers (I have to work out if this is possible yet)
