### PR TITLE
Allow timezone identifier in DateFormatHelper

### DIFF
--- a/src/main/java/me/nucleartux/date/DateFormatHelper.java
+++ b/src/main/java/me/nucleartux/date/DateFormatHelper.java
@@ -15,7 +15,7 @@ public class DateFormatHelper {
 
       try
       {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US);
         initialDate.setTime(sdf.parse(date));
       }
       catch (ParseException e)


### PR DESCRIPTION
Fixes timezone bug in https://github.com/nucleartux/react-native-date/pull/11
