### PR TITLE
Updated index.android.js to enable direct import and modified README accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ import DateAndroid from 'react-native-date';
 const AwesomeProject = React.createClass({
   handleTimeClick: function () {
     DateAndroid.showTimepicker(function() {}, function(hour, minute) {
-      console.log(`${hour}:${minute+1});
+      console.log(`${hour}:${minute+1}`);
     });
   },
   handleDateClick: function () {

--- a/README.md
+++ b/README.md
@@ -56,29 +56,39 @@ public class MainActivity extends ReactActivity {
 ```js
 // file: index.android.js
 
-var React = require('react-native');
-var { AppRegistry,StyleSheet,Text,View,TouchableOpacity,NativeModules } = React;
+import React, { AppRegistry, StyleSheet, Text, View, TouchableOpacity } from 'react-native';
+import DateAndroid from 'react-native-date';
 
-var AwesomeProject = React.createClass({
-    handleClick: function () {
-      NativeModules.DateAndroid.showTimepicker(function() {}, function(hour, minute) {
-        console.log(hour + ":" + minute);
-      });
-    },
-    render: function() {
-        return (
-            <View style={styles.container}>
-              <TouchableOpacity onPress={this.handleClick}>
-                <Text style={styles.instructions}>
-                  Click me
-                </Text>
-              </TouchableOpacity>
-            </View>
-        );
-    }
+const AwesomeProject = React.createClass({
+  handleTimeClick: function () {
+    DateAndroid.showTimepicker(function() {}, function(hour, minute) {
+      console.log(`${hour}:${minute+1});
+    });
+  },
+  handleDateClick: function () {
+    DateAndroid.showDatepicker(function() {}, function(year, month, day) {
+      console.log(`${year}/${month+1}/${day}`);
+    });
+  },
+  render: function() {
+    return (
+      <View style={styles.container}>
+        <TouchableOpacity onPress={this.handleDateClick}>
+          <Text style={styles.instructions}>
+            Click me to select Date
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={this.handleTimeClick}>
+          <Text style={styles.instructions}>
+            Click me to select Time
+          </Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
 });
 
-var styles = StyleSheet.create({
+const styles = StyleSheet.create({
   instructions: {
     textAlign: 'center',
     color: '#333333',

--- a/index.android.js
+++ b/index.android.js
@@ -1,15 +1,24 @@
 /**
- * @providesModule ToastAndroid
+ * @providesModule DateAndroid
  */
 
 'use strict';
 
 /**
- * This exposes the native ToastAndroid module as a JS module. This has a function 'show'
- * which takes the following parameters:
+ * This exposes the native DatePicker module as a JS module. This has the static functions:
  *
- * 1. String message: A string with the text to toast
- * 2. int duration: The duration of the toast. May be ToastAndroid.SHORT or ToastAndroid.LONG
+ * showDatepicker(Callback errorCallback, Callback successCallback)
+ * showDatepickerWithInitialDate(String initialDateString, Callback errorCallback, Callback successCallback)
+ * showDatepickerWithInitialDateInMilliseconds(String initialDateString, Callback errorCallback, Callback successCallback)
+ * showDatepickerWithInitialMinMaxDate(String initialDateString, String minDateString, String maxDateString, Callback errorCallback, Callback successCallback)
+ *
+ * showTimepicker(Callback errorCallback, Callback successCallback)
+ * showTimepickerWithInitialTime(String initialDateString, Callback errorCallback, Callback successCallback)
+ *
+ * The DatePicker invokes the successCallback with: mSuccessCallback.invoke(year, month, day);
+ * [The month comes from the `java.util.Calendar`, so it is going from 0-11]
+ * The TimePicker invokes the successCallback with: mSuccessCallback.invoke(hour, minute);
+ *
  */
 var { NativeModules } = require('react-native');
 module.exports = NativeModules.DateAndroid;


### PR DESCRIPTION
Removed the ToastAndroid stuff from index.android.js to enable directly importing DateAndroid from `react-native-date` .
Also updated the example in step 5 in the `README` to reflect this change, also added example for Datepicker, this may be the answer to [issue No 16](https://github.com/nucleartux/react-native-date/issues/16).
