### PR TITLE
upgrade react-native to 0.19.0, refactor to use getCurrentActivity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,5 +30,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.11.+'
+    compile 'com.facebook.react:react-native:0.19.0'
 }

--- a/src/main/java/me/nucleartux/date/DateModule.java
+++ b/src/main/java/me/nucleartux/date/DateModule.java
@@ -9,11 +9,9 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 
 public class DateModule extends ReactContextBaseJavaModule {
-  private Activity mActivity = null;
 
-  public DateModule(ReactApplicationContext reactContext, Activity activity) {
+  public DateModule(ReactApplicationContext reactContext) {
     super(reactContext);
-    mActivity = activity;
   }
 
   @Override
@@ -31,7 +29,10 @@ public class DateModule extends ReactContextBaseJavaModule {
                                             Callback successCallback) {
     DialogFragment dateDialog = new DatePicker(DateFormatHelper.parseDate(initialDateString),
             errorCallback, successCallback);
-    dateDialog.show(mActivity.getFragmentManager(), "datePicker");
+    Activity activity = getCurrentActivity();
+    if (activity != null) {
+      dateDialog.show(activity.getFragmentManager(), "datePicker");
+    }
   }
 
   @ReactMethod
@@ -39,7 +40,10 @@ public class DateModule extends ReactContextBaseJavaModule {
                                             Callback successCallback) {
     DialogFragment dateDialog = new DatePicker(DateFormatHelper.parseDateInMilliseconds(Long.parseLong(initialDateString)),
             errorCallback, successCallback);
-    dateDialog.show(mActivity.getFragmentManager(), "datePicker");
+    Activity activity = getCurrentActivity();
+    if (activity != null) {
+      dateDialog.show(activity.getFragmentManager(), "datePicker");
+    }
   }
 
   @ReactMethod
@@ -50,7 +54,10 @@ public class DateModule extends ReactContextBaseJavaModule {
             DateFormatHelper.parseDate(minDateString),
             DateFormatHelper.parseDate(maxDateString),
             errorCallback, successCallback);
-    dateDialog.show(mActivity.getFragmentManager(), "datePicker");
+    Activity activity = getCurrentActivity();
+    if (activity != null) {
+      dateDialog.show(activity.getFragmentManager(), "datePicker");
+    }
   }
 
   @ReactMethod
@@ -63,6 +70,9 @@ public class DateModule extends ReactContextBaseJavaModule {
                                             Callback successCallback) {
     DialogFragment dateDialog = new TimePicker(DateFormatHelper.parseDate(initialDateString),
             errorCallback, successCallback);
-    dateDialog.show(mActivity.getFragmentManager(), "timePicker");
+    Activity activity = getCurrentActivity();
+    if (activity != null) {
+      dateDialog.show(activity.getFragmentManager(), "timePicker");
+    }
   }
 }

--- a/src/main/java/me/nucleartux/date/ReactDatePackage.java
+++ b/src/main/java/me/nucleartux/date/ReactDatePackage.java
@@ -13,17 +13,12 @@ import java.util.Collections;
 import java.util.List;
 
 public class ReactDatePackage implements ReactPackage {
-    private Activity mActivity = null;
-
-    public ReactDatePackage(Activity activity){
-        mActivity = activity;
-    }
 
     @Override
     public List<NativeModule> createNativeModules(
                                 ReactApplicationContext reactContext) {
       List<NativeModule> modules = new ArrayList<>();
-      modules.add(new DateModule(reactContext, mActivity));
+      modules.add(new DateModule(reactContext));
       return modules;
     }
 


### PR DESCRIPTION
Fixes #26 

Now rather than passing in the MainActivity through the package
constructor, use getCurrentActivity to get a reference to an Activity
instance.

This is actually one of my first times opening a PR for an open source project, so apologies if I'm missing anything. I'm very open to feedback and fixing anything that doesn't look right!
