### PR TITLE
Remove peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
     "mobile",
     "native"
   ],
-  "peerDependencies": {
-    "react-native": ">=0.5"
-  },
   "author": {
     "name": "Adrov Igor"
   },


### PR DESCRIPTION
peerDependencies make it impossible to use RC versions of RN. It's generally agreed that they're bad practice and should be removed.
